### PR TITLE
Fix Link Existing template label to match bot handler

### DIFF
--- a/.github/ISSUE_TEMPLATE/link_existing_component.yml
+++ b/.github/ISSUE_TEMPLATE/link_existing_component.yml
@@ -1,7 +1,7 @@
 name: "Stage 3: Link Existing Component"
 description: Link a registered model component to computational grids to create a component configuration (Stage 3 of 4)
 title: "[EMD] Stage 3: Link Existing Component: [do not edit]"
-labels: ['emd-submission', 'component_config', 'Review']
+labels: ['emd-submission', 'link_existing_component', 'Review']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

The Link Existing Component template applied the label `component_config` (the resulting schema/folder name) while every other issue template uses a label matching its template name (`horizontal_grid_cell.yml` → `horizontal_grid_cell`, `model_family.yml` → `model_family`, etc.).

The bot dispatcher in [`CMIPLD/cmipld/generate/new_issue.py`](https://github.com/WCRP-CMIP/CMIPLD/blob/main/cmipld/generate/new_issue.py) looks up handlers under `.github/ISSUE_SCRIPT/<label>.py`. The handler file already in this repo is named `link_existing_component.py`, so the template-applied label needs to match that name.

As a secondary effect, the `component_config` label did not exist in the repo, so GitHub was silently dropping it from filed issues. This left #483 (`openifs-48r1` Link Existing) and #499 (`lpj-guess-4.1` Link Existing) with only `emd-submission` and `Review` applied, both of which the bot's `IGNORE_LABELS` set strips, so `get_issue_type_from_labels` returned `None` and the bot exited with `No matching issue type found — not an EMD submission, skipping.` (see [#483#issuecomment-4569288597](https://github.com/WCRP-CMIP/Essential-Model-Documentation/issues/483#issuecomment-4569288597) from @wolfiex on 2026-05-29 flagging exactly this).

The `link_existing_component` label has now been created in the repo. With this template change and the label in place, future Link Existing submissions will trigger the bot correctly. The two existing issues will need to be re-labelled (which I will do separately after this merges) to re-trigger their bot runs via `issues: edited`.
