### PR TITLE
| v128 | Fix Stage 4 model handler missing 'name' field

### DIFF
--- a/.github/ISSUE_SCRIPT/model.py
+++ b/.github/ISSUE_SCRIPT/model.py
@@ -114,6 +114,7 @@ def run(parsed_issue, issue, dry_run=False):
         "@type":          ["emd", "wcrp:model", "esgvoc:Model"],
         "validation_key": source_id,
         "ui_label":       source_id,
+        "name":           source_id,
     }
 
     if family and family.lower() not in ('not specified', 'none', ''):


### PR DESCRIPTION
## Summary

The Stage 4 source_id submission pipeline has been failing for every submission so far. Open issues hit by this bug:

- #173 `BCC-CSM3-MR` (open since 2026-04-20)
- #440 `FGOALS-f3.5-L` (open since 2026-05-20)
- #563 `AWI-ESM3-4-2-veg-HR` (mine, today)

All three got the identical bot comment:

> | **Field** | **Error Type** | **Input Value** | **Input Type** | **Message** |
> | --- | --- | --- | --- | --- |
> | name | missing | `None` | None | Field required |

In #440 @JamesAnstey already flagged that the error message was opaque. Following that thread suggested the cause was a period in `FGOALS-f3.5-L`. After investigating I found the period was incidental. Every Stage 4 submission hits this regardless of the submitted source_id.

## Root cause

`.github/ISSUE_SCRIPT/model.py` builds the data dict like this:

```python
data = {
    "@context":       "_context",
    "@id":            source_id,
    "@type":          ["emd", "wcrp:model", "esgvoc:Model"],
    "validation_key": source_id,
    "ui_label":       source_id,
}
```

`validation_key` and `ui_label` are populated from the parsed Model Name, but the `name` field is never set.

The esgvoc `Model` schema (`PlainTermDataDescriptor` subclass) requires `name`:

```python
class Model(PlainTermDataDescriptor):
    name: str = Field(description="...", min_length=1)
```

`cmipld/utils/similarity/pydantic_validator.py` only aliases `validation_key -> drs_name`, not `validation_key -> name`:

```python
CMIPLD_KEY_TRANSLATION = {
    "validation_key": "drs_name",
    "@id":            "id",
    "@type":          "type",
    "@context":       "context",
}
```

So pydantic always sees `name` as missing and fails on STEP 1 (pycmipld validation) before reaching `update()` or any file write.

## Fix

One line. Add `"name": source_id` to the `data` dict alongside `validation_key` and `ui_label`. The handler's `update()` already does `data.pop('name', None)` before disk write so the on-disk JSON shape is unchanged.

```diff
     data = {
         "@context":       "_context",
         "@id":            source_id,
         "@type":          ["emd", "wcrp:model", "esgvoc:Model"],
         "validation_key": source_id,
         "ui_label":       source_id,
+        "name":           source_id,
     }
```

## Test plan

Reproduced and verified locally end-to-end:

1. Faithful reproduction of the validation pipeline (current handler -> `pycmipld._prepare_dict` -> real `esgvoc.api.data_descriptors.EMD_models.Model.model_validate`) produced the bot's error verbatim:

```
❌ name | missing | Field required
```

2. Patching the local copy of `.github/ISSUE_SCRIPT/model.py` with the one-line addition and re-running the same pipeline against #563's parsed body fields:

```
Handler-produced dict has 'name'? True   value = 'AWI-ESM3-4-2-veg-HR'
After pycmipld translation, 'name' = 'AWI-ESM3-4-2-veg-HR'

✅ PATCHED HANDLER + REAL PYDANTIC SCHEMA: PASSED
   m.name = 'AWI-ESM3-4-2-veg-HR'
   m.family = 'awi-esm3'
   m.dynamic_components = ['atmosphere', 'ocean', 'sea-ice', 'land-surface']
```

3. To validate in CI: once this is merged, re-trigger validation on #173, #440 and #563 by editing each issue. All three should produce PRs.

cc @wolfiex @JamesAnstey @charliepascoe @TongwenWu @bianH522-iap