### PR TITLE
add links to CMIP7 source_id guidance page in docs

### DIFF
--- a/docs/Information_for_Submitters/Submission-Guide.md
+++ b/docs/Information_for_Submitters/Submission-Guide.md
@@ -88,6 +88,7 @@ Use this form when the component is already registered and you only need to bind
 The model record assembles the complete system — listing every component configuration, declaring which earth system realms are active or prescribed, recording coupling relationships, and referencing the ESM family. This creates the official CMIP `source_id`.
 
 **You will need:** component config IDs from Stage 3, ESM family ID, coupling topology, calendar type.
+Please also read the [guidance on choosing a `source_id`](https://wcrp-cmip.github.io/cmip7-guidance/docs/CMIP7/Source_ID_guidance/).
 
 **Following review, you will receive:** a registered `source_id`.
 

--- a/docs/Reviewer_Guidance/Reviewer_Information.md
+++ b/docs/Reviewer_Guidance/Reviewer_Information.md
@@ -73,6 +73,7 @@ Reviewers should ping others @EMD-reviewers if not confident about a submission.
 - IDs must not contain underscores or spaces.
 - Any periods `.` must be replaced with hyphens `-`. This applies to source IDs, model family names, and component version strings.
 - Confirm this for every identifier in the submitted record.
+- `source_id`'s in particular should follow the rules given in the [CMIP7 guidance pages](https://wcrp-cmip.github.io/cmip7-guidance/docs/CMIP7/Source_ID_guidance/).
 
 **Links and references**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,9 +140,10 @@ Keeping them in one folder with a type field, rather than two separate folders, 
 
 ### Source / Model
 
-The model (source_id) record does not describe any individual component or grid. It describes a system — which component configurations are present, which realms are active or prescribed, and how the components exchange information with one another. The coupling and embedding topology lives here because it is a property of the assembled system, not of any individual part.
+The model (`source_id`) record does not describe any individual component or grid. It describes a system — which component configurations are present, which realms are active or prescribed, and how the components exchange information with one another. The coupling and embedding topology lives here because it is a property of the assembled system, not of any individual part.
 
-The model record is deliberately thin. It holds IDs of component configurations and an ESM family reference, not copies of their content. If an ocean grid specification needs to be corrected, the correction happens in one grid cell record and is immediately reflected in every model that references it. The idea is that once registered, the model id can be used directly within a project. In another project wants to use a similar (but not identical) configuration, then a new source id would be required. 
+The model record is deliberately thin. It holds IDs of component configurations and an ESM family reference, not copies of their content. If an ocean grid specification needs to be corrected, the correction happens in one grid cell record and is immediately reflected in every model that references it. The idea is that once registered, the model id can be used directly within a project. If another project wants to use a similar (but not identical) configuration, then a new `source_id` would generally be required. 
+For further guidance on specifying a `source_id`, please see the [CMIP7 guidance pages](https://wcrp-cmip.github.io/Essential-Model-Documentation/docs/#source-model).
 
 ### The design in one sentence
 


### PR DESCRIPTION
Suggest to add these links to https://wcrp-cmip.github.io/cmip7-guidance/docs/CMIP7/Source_ID_guidance/ to help ensure submitters see this info when choosing their `source_id`.