### PR TITLE
add source id guidance link to model registration issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/model.yml
+++ b/.github/ISSUE_TEMPLATE/model.yml
@@ -43,6 +43,8 @@ body:
         For CMIP, this becomes the official **source_id**.
         
         **Examples:** CNRM-ESM2-1, HadGEM3-GC31-LL, CESM2, ACCESS-ESM1-5
+
+        For further guidance on choosing a source_id, please see the <a href="https://wcrp-cmip.github.io/cmip7-guidance/docs/CMIP7/Source_ID_guidance">CMIP7 guidance pages</a>.
         
         </details>
       placeholder: "CNRM-ESM2-1"


### PR DESCRIPTION
Suggest to add link to source_id guidance in the form used to register a model (stage 4), to help ensure submitters see this guidance before deciding their source_id. So, same thing in spirit as #1011, but on the model registration form.

@wolfiex, it's a one-line addition but I'm not sure if I've put it in the right place - so please let me know if this is the wrong branch to target or wrong file to edit!