### PR TITLE
Fix x/y velocity mistakes

### DIFF
--- a/horizontal_computational_grid/h137.json
+++ b/horizontal_computational_grid/h137.json
@@ -5,7 +5,7 @@
   "arrangement": "arakawa-b",
   "horizontal_subgrids": [
     "g200-mass",
-    "g189-velocity"
+    "g189-x-velocity-y-velocity"
   ],
   "@context": "_context",
   "@type": [

--- a/horizontal_computational_grid/h138.json
+++ b/horizontal_computational_grid/h138.json
@@ -5,7 +5,7 @@
   "arrangement": "arakawa-b",
   "horizontal_subgrids": [
     "g181-mass",
-    "g181-velocity"
+    "g181-x-velocity-y-velocity"
   ],
   "@context": "_context",
   "@type": [

--- a/horizontal_computational_grid/h139.json
+++ b/horizontal_computational_grid/h139.json
@@ -5,7 +5,7 @@
   "arrangement": "arakawa-b",
   "horizontal_subgrids": [
     "g160-mass",
-    "g160-velocity"
+    "g160-x-velocity-y-velocity"
   ],
   "@context": "_context",
   "@type": [

--- a/horizontal_subgrid/g160-x-velocity-y-velocity.json
+++ b/horizontal_subgrid/g160-x-velocity-y-velocity.json
@@ -1,16 +1,16 @@
 {
-    "validation_key": "g181-velocity",
+    "validation_key": "g160-velocity",
     "ui_label": "",
     "description": "",
     "cell_variable_type": [
         "x-velocity", "y-velocity"
     ],
-    "horizontal_grid_cells": "g181",
+    "horizontal_grid_cells": "g160",
     "@context": "_context",
     "@type": [
         "wcrp:horizontal_subgrid",
         "esgvoc:HorizontalSubgrid",
         "emd"
     ],
-    "@id": "g181-velocity"
+    "@id": "g160-x-velocity-y-velocity"
 }

--- a/horizontal_subgrid/g181-x-velocity-y-velocity.json
+++ b/horizontal_subgrid/g181-x-velocity-y-velocity.json
@@ -1,16 +1,16 @@
 {
-    "validation_key": "g160-velocity",
+    "validation_key": "g181-velocity",
     "ui_label": "",
     "description": "",
     "cell_variable_type": [
         "x-velocity", "y-velocity"
     ],
-    "horizontal_grid_cells": "g160",
+    "horizontal_grid_cells": "g181",
     "@context": "_context",
     "@type": [
         "wcrp:horizontal_subgrid",
         "esgvoc:HorizontalSubgrid",
         "emd"
     ],
-    "@id": "g160-velocity"
+    "@id": "g181-x-velocity-y-velocity"
 }

--- a/horizontal_subgrid/g189-x-velocity-y-velocity.json
+++ b/horizontal_subgrid/g189-x-velocity-y-velocity.json
@@ -12,5 +12,5 @@
         "esgvoc:HorizontalSubgrid",
         "emd"
     ],
-    "@id": "g189-velocity"
+    "@id": "g189-x-velocity-y-velocity"
 }


### PR DESCRIPTION
Fix the errors I introduced` when trying to "velocity -> "x-velocty, y_velocity".

This affects `h139.json`, `h138.json`, `h137.json` and `g160-velocity.json`, `g181-velocity.json`, `g189-velocity.json`. The last three are also renamed to `g160-x-velocity-y-velocity.json`, `g181-x-velocity-y-velocity.json`, `g189-x-velocity-y-velocity.json`.


