### PR TITLE
Update g219.json

### DIFF
--- a/horizontal_grid_cell/g219.json
+++ b/horizontal_grid_cell/g219.json
@@ -14,7 +14,7 @@
   "truncation_method": "",
   "truncation_number": "",
   "units": "degree",
-  "westernmost_longitude": 0,
+  "westernmost_longitude": 0.5,
   "x_resolution": 1,
   "y_resolution": 0.5,
   "@context": "_context",


### PR DESCRIPTION
Fixed g219 westernmost longitude for U-cell incorrectly set in #1114. The corresponding T-cell and V-cells are registered as [g211](https://github.com/WCRP-CMIP/Essential-Model-Documentation/pull/1016) and [g212](https://github.com/WCRP-CMIP/Essential-Model-Documentation/pull/1115).

This grid cell is neither used in merged code nor in open PRs.