### PR TITLE
Let the modify handler overwrite the file it is editing

### DIFF
--- a/.github/ISSUE_SCRIPT/modify.py
+++ b/.github/ISSUE_SCRIPT/modify.py
@@ -233,11 +233,16 @@ def run(parsed_issue, issue, dry_run=False):
     contributors = [c.strip() for c in collab_str.split(',') if c.strip()] \
                    if collab_str else []
 
+    # `_force_modify` tells new_issue.py that overwriting an existing file is the
+    # intent here, not an accident. Without it the writer's "File already exists"
+    # guard rejects every submission from this form, since the guard only skips
+    # when issue_kind == 'modify' and no handler sets issue_kind.
     return {
         rel_path:         data,
         '_author':        issue.get('author'),
         '_contributors':  contributors,
         '_make_pull':     True,
+        '_force_modify':  {rel_path},
         '_justification': justification,
         '_modify_key':    key,
         '_modify_old':    old_value,


### PR DESCRIPTION
I do not think the modify form can complete a change at all. Every submission through `modify.yml` gets rejected before the file is written.

`new_issue.py` refuses to write when the target exists:

    force_modify_paths = files_to_write.get('_force_modify', set())
    if issue_kind == 'new' and os.path.exists(output_path) \
            and file_path not in force_modify_paths:

The guard is right for new issues, but I could not find any handler here that reads `issue_kind`, so it always defaults to `'new'` and fires on the one form meant to write to an existing file. The error then tells you to change **Issue Kind** to _Modify_, and `modify.yml` has no such field.

I found `_force_modify` already in the writer as the escape hatch for this, just never declared. This declares it. Nothing in CMIPLD changes, and both loops over `files_to_write` skip keys starting with `_`, so I do not think it touches any other form.

I hit this on #1251, where the handler parsed my request and retitled the issue before the writer rejected it. #868 and #937 are the only other uses of the form and both died earlier on the key-parsing bug you fixed in `bdc118b2`, so #1251 may be the first submission to reach the write step.

Two things I have not fixed. `validate_and_fix_json` still runs over the whole file afterwards, which on #937 rejected your `g110` edit on fields you never touched. And the CONTRIBUTING section 2 "Modify" links set `issue_kind` on the stage forms, so they quietly create new entries instead of editing, which I count at least five people hitting since June. Both look like design calls I would rather leave to you.

To test, `new-issue.yml` takes an `issue_number` via `workflow_dispatch`, so re-running it on #1251 hits the exact failure.