### PR TITLE
Split reference lists that arrive space-joined

### DIFF
--- a/.github/ISSUE_SCRIPT/model.py
+++ b/.github/ISSUE_SCRIPT/model.py
@@ -88,7 +88,21 @@ def _parse_list(value, lowercase=False) -> list:
 def _parse_refs(value) -> list:
     if isinstance(value, list):
         return [str(v).strip() for v in value if str(v).strip()]
-    return [v.strip() for v in re.split(r'[,\s]+', str(value)) if v.strip()]
+    s = str(value)
+    # Split on newlines or commas first. The issue parser collapses newlines to
+    # spaces, so several URLs can arrive as one whitespace-separated string; split
+    # those too. Only when more than one URL is present, otherwise a reference like
+    # "Smith et al. 2020 https://doi.org/..." would be torn apart, and free text
+    # would survive as a single entry either way.
+    if '\n' in s:
+        parts = s.split('\n')
+    elif ',' in s:
+        parts = s.split(',')
+    elif s.count('http') > 1:
+        parts = re.split(r'\s+(?=https?://)', s)
+    else:
+        parts = [s]
+    return [v.strip() for v in parts if v.strip()]
 
 
 # Multi-char arrow separators for embedded-component pairs.  Bare '>' is

--- a/.github/ISSUE_SCRIPT/model_component.py
+++ b/.github/ISSUE_SCRIPT/model_component.py
@@ -40,9 +40,24 @@ def _slugify(s: str) -> str:
     return s.strip('-')
 
 
-def _parse_list(value: str) -> list:
-    delim = '\n' if '\n' in value else ','
-    return [v.strip() for v in value.split(delim) if v.strip()]
+def _parse_list(value) -> list:
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    s = str(value)
+    # Split on newlines or commas first. The issue parser collapses newlines to
+    # spaces, so several URLs can arrive as one whitespace-separated string; split
+    # those too. Only when more than one URL is present, otherwise a reference like
+    # "Smith et al. 2020 https://doi.org/..." would be torn apart, and free text
+    # would survive as a single entry either way.
+    if '\n' in s:
+        parts = s.split('\n')
+    elif ',' in s:
+        parts = s.split(',')
+    elif s.count('http') > 1:
+        parts = re.split(r'\s+(?=https?://)', s)
+    else:
+        parts = [s]
+    return [v.strip() for v in parts if v.strip()]
 
 
 def run(parsed_issue, issue, dry_run=False):

--- a/.github/ISSUE_SCRIPT/model_family.py
+++ b/.github/ISSUE_SCRIPT/model_family.py
@@ -42,14 +42,20 @@ def _parse_list(value) -> list:
     if isinstance(value, list):
         return [str(v).strip() for v in value if str(v).strip()]
     s = str(value)
-    # Split on newlines or commas first; fall back to whitespace (e.g. space-separated URLs)
+    # Split on newlines or commas first. The issue parser collapses newlines to
+    # spaces, so several URLs can arrive as one whitespace-separated string; split
+    # those too. Only when more than one URL is present, otherwise a reference like
+    # "Smith et al. 2020 https://doi.org/..." would be torn apart, and free text
+    # would survive as a single entry either way.
     if '\n' in s:
         parts = s.split('\n')
     elif ',' in s:
         parts = s.split(',')
-    else:
+    elif s.count('http') > 1:
         import re
         parts = re.split(r'\s+(?=https?://)', s)
+    else:
+        parts = [s]
     return [v.strip() for v in parts if v.strip()]
 
 


### PR DESCRIPTION
Reference lists with more than one DOI arrive as a single joined string. 44 of the 100 registered model_components have this, including inmice2m, fesim-2-7, cam-ice1, m-sim and mricom-5-4-sea-ice, so none of those references resolve as links.

The submitter is not doing anything wrong. On #1227 the two DOIs sit on separate lines in the issue body, and `_parse_list` in `model_component.py` does split on newlines:

    delim = '\n' if '\n' in value else ','
    return [v.strip() for v in value.split(delim) if v.strip()]

By the time the handler sees the value the newlines are gone, so it falls through to the comma branch, finds no comma, and returns the whole string as one item.

You already found this and fixed it in `model_family.py` in 80902cf9, with the comment "fall back to whitespace (e.g. space-separated URLs)". This applies the same fix to `model_component.py`, where most references are entered, and to `_parse_refs` in `model.py`.

`_parse_refs` had the opposite problem. It split on `[,\s]+`, so a free-text reference like the one on co2box-v1-0 would have come out as one entry per word. Stage 4 has only had bare URLs so far, which is why nobody hit it.

I added one guard to your version, splitting on whitespace only when the string holds more than one URL. Without it "Smith et al. 2020 https://doi.org/..." is torn in two, and three registered components already pair a label with a DOI that way. All three handlers now behave identically on newline, comma, space-joined, free text and list input.

The duplication is why this survived, since the fix landed in one copy of four. A shared helper in `.github/ISSUE_SCRIPT/` would prevent the next one, and `_parse_list` in `vertical_computational_grid.py` is dead code that could go at the same time. Both look like your calls rather than mine.

This does not repair the 44 already merged. I can put together a one-off pass over src-data if you want it.