### PR TITLE
Clear the opposite review label on the PR, not just the issue

### DIFF
--- a/.github/workflows/review-response.yml
+++ b/.github/workflows/review-response.yml
@@ -65,16 +65,18 @@ jobs:
           #   - remove changes-made from PR + issues
           #   - mirror the review-state label ($LABEL) to linked issues so the
           #     Progress Tracker (which scans issues, not PRs) can see it
-          #   - remove the opposite review-state label from issues so an issue
-          #     never carries both 'approved' and 'changes-requested' at once
+          #   - remove the opposite review-state label from the PR and from the
+          #     linked issues, so neither ever carries both 'approved' and
+          #     'changes-requested' at once
           if [ "$REVIEW_STATE" = "changes_requested" ] || [ "$REVIEW_STATE" = "approved" ]; then
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "changes-made" 2>/dev/null || true
-
             if [ "$REVIEW_STATE" = "approved" ]; then
               OPPOSITE_LABEL="changes-requested"
             else
               OPPOSITE_LABEL="approved"
             fi
+
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "changes-made"    2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$OPPOSITE_LABEL" 2>/dev/null || true
 
             while IFS= read -r issue_num; do
               [ -z "$issue_num" ] && continue


### PR DESCRIPTION
Approving a pull request leaves `changes-requested` sitting on it. #884, #986 and #1019 all currently carry both `approved` and `changes-requested`, while their linked issues carry only `approved`.

The rule already exists in `review-response.yml`, and its own comment states it: "remove the opposite review-state label from issues so an issue never carries both 'approved' and 'changes-requested' at once". It is applied inside the issue loop and never to the pull request, which only gets:

    gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "changes-made"

`OPPOSITE_LABEL` is computed a few lines further down, after that call, so this moves the assignment above the PR edits and adds the second removal. The issue loop is untouched.

I kept `changes-made` being cleared on approval. It is a work-queue flag rather than a record, and `label:changes-made` is the re-review filter on the reviewer page, so leaving it in place would park approved PRs in that queue permanently.

Two things I have not changed. `reviewer-comment` is never removed by anything, which is how #1019 came to carry all four labels at once. And a Comment review deliberately does not touch the state labels, so it cannot tidy a PR that is already inconsistent. Both look like design calls I would rather leave to you.

This does not repair the three PRs that are already inconsistent. Those need their labels clearing by hand.